### PR TITLE
change header include order to fix gcc errors in qt headers

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1,5 +1,5 @@
-#include "MainWindow.h"
 #include "ui_MainWindow.h"
+#include "MainWindow.h"
 #include "SCLDockWidget.h"
 #include "ExpressViewDockWidget.h"
 #include "EntityTypeList.h"


### PR DESCRIPTION
errors were like the following

In file included from /usr/include/qt4/QtCore/qvariant.h:49:0,
                 from /usr/include/qt4/QtCore/QVariant:1,
                 from /opt/step/SCLView/build/ui_MainWindow.h:13,
                 from /opt/step/SCLView/MainWindow.cpp:2:
/usr/include/qt4/QtCore/qmap.h: In member function ‘QMapData::Node\* QMap<Key, T>::node_create(QMapData_, QMapData::Node_*, const Key&, const T&)’:
/usr/include/qt4/QtCore/qmap.h:456:14: error: expected type-specifier before ‘&’ token
/usr/include/qt4/QtCore/qmap.h:456:14: error: expected ‘)’ before ‘&’ token
/usr/include/qt4/QtCore/qmap.h:456:32: error: expected ‘;’ before ‘)’ token
/usr/include/qt4/QtCore/qmap.h:458:18: error: expected type-specifier before ‘&’ token
/usr/include/qt4/QtCore/qmap.h:458:18: error: expected ‘)’ before ‘&’ token
/usr/include/qt4/QtCore/qmap.h:458:38: error: expected ‘;’ before ‘)’ token
